### PR TITLE
Ignore the enter key if the component is closed (addresses #29)

### DIFF
--- a/src/Multiselect.elm
+++ b/src/Multiselect.elm
@@ -481,7 +481,7 @@ update msg (Model model) =
                 , Nothing
                 )
 
-            else if key == Keycodes.return then
+            else if key == Keycodes.return && model.status == Opened then
                 case model.hovered of
                     Nothing ->
                         let


### PR DESCRIPTION
It looks like the simplest way to deal with #29 is to simply not handle the enter key when the component is closed. This way, we don't select the last hovered item. I'm happy to make the change in another way if you prefer! Thanks again for this package.