### PR TITLE
Make example modules compile

### DIFF
--- a/example/src/DynamicExample.elm
+++ b/example/src/DynamicExample.elm
@@ -1,4 +1,4 @@
-module Main exposing (..)
+module DynamicExample exposing (..)
 
 import Browser
 import Html exposing (Html, button, div, text)
@@ -42,7 +42,7 @@ type alias Model =
 
 initModel : Model
 initModel =
-    { multiselectC = Multiselect.initModel valuesC "C"
+    { multiselectC = Multiselect.initModel valuesC "C" Multiselect.Hide
     }
 
 
@@ -82,7 +82,7 @@ update msg model =
                 values =
                     List.map (\v -> ( v, v )) vs
             in
-            ( { model | multiselectC = Multiselect.populateValues multiselectModel values []}, Cmd.none )
+            ( { model | multiselectC = Multiselect.populateValues multiselectModel values [] }, Cmd.none )
 
         Prepopulate (Err _) ->
             Debug.log "error" ( model, Cmd.none )

--- a/example/src/MinimalExample.elm
+++ b/example/src/MinimalExample.elm
@@ -1,4 +1,4 @@
-module Main exposing (..)
+module MinimalExample exposing (..)
 
 -- Import Multiselect
 
@@ -71,8 +71,8 @@ type alias Model =
 
 initModel : Model
 initModel =
-    { multiselectA = Multiselect.initModel valuesA "A"
-    , multiselectB = Multiselect.initModel valuesB "B"
+    { multiselectA = Multiselect.initModel valuesA "A" Multiselect.Hide
+    , multiselectB = Multiselect.initModel valuesB "B" Multiselect.Hide
     }
 
 

--- a/src/Multiselect.elm
+++ b/src/Multiselect.elm
@@ -54,7 +54,6 @@ import Browser.Dom as Dom
 import Browser.Events as BrowserEvents
 import DOM
 import Html exposing (Html)
-import Html.Events as Events
 import Html.Styled
     exposing
         ( div
@@ -69,8 +68,7 @@ import Multiselect.Keycodes as Keycodes
 import Multiselect.SelectCss as SelectCss
 import Process
 import String
-import Task as Task exposing (Task)
-import Time
+import Task exposing (Task)
 
 
 type Status


### PR DESCRIPTION
The provided examples were not compiling due to missing arguments to `initModel` and mismatching module names.