### PR TITLE
Add support for single selection

### DIFF
--- a/example/src/DynamicExample.elm
+++ b/example/src/DynamicExample.elm
@@ -1,4 +1,4 @@
-module Main exposing (..)
+module DynamicExample exposing (..)
 
 import Browser
 import Html exposing (Html, button, div, text)
@@ -42,7 +42,7 @@ type alias Model =
 
 initModel : Model
 initModel =
-    { multiselectC = Multiselect.initModel valuesC "C"
+    { multiselectC = Multiselect.initModel valuesC "C" Multiselect.Hide
     }
 
 
@@ -82,7 +82,7 @@ update msg model =
                 values =
                     List.map (\v -> ( v, v )) vs
             in
-            ( { model | multiselectC = Multiselect.populateValues multiselectModel values []}, Cmd.none )
+            ( { model | multiselectC = Multiselect.populateValues multiselectModel values [] }, Cmd.none )
 
         Prepopulate (Err _) ->
             Debug.log "error" ( model, Cmd.none )

--- a/example/src/DynamicExample.elm
+++ b/example/src/DynamicExample.elm
@@ -42,7 +42,11 @@ type alias Model =
 
 initModel : Model
 initModel =
-    { multiselectC = Multiselect.initModel valuesC "C" Multiselect.Hide
+    let
+        config =
+            Multiselect.defaultConfig
+    in
+    { multiselectC = Multiselect.initModel { config | values = valuesC, tag = "C" }
     }
 
 

--- a/example/src/Main.elm
+++ b/example/src/Main.elm
@@ -82,11 +82,21 @@ type alias Model =
 
 initModel : Model
 initModel =
-    { multiselectA = Multiselect.initModel valuesA "A" Multiselect.Hide
-    , multiselectB = Multiselect.initModel valuesB "B" Multiselect.Hide
-    , multiselectC = Multiselect.initModel valuesC "C" Multiselect.Hide
-    , multiselectTagged = Multiselect.initModel valuesD "Tagged" Multiselect.Hide
-    , multiselectTaggedShowPrefix = Multiselect.initModel valuesD "TaggedShowPrefix" Multiselect.Show
+    let
+        config =
+            Multiselect.defaultConfig
+    in
+    { multiselectA = Multiselect.initModel { config | values = valuesA, tag = "A" }
+    , multiselectB = Multiselect.initModel { config | values = valuesB, tag = "B" }
+    , multiselectC = Multiselect.initModel { config | values = valuesC, tag = "C" }
+    , multiselectTagged = Multiselect.initModel { config | values = valuesD, tag = "Tagged" }
+    , multiselectTaggedShowPrefix =
+        Multiselect.initModel
+            { config
+                | values = valuesD
+                , tag = "TaggedShowPrefix"
+                , inputInMenu = Multiselect.Show
+            }
     , selectedA = []
     }
 
@@ -150,11 +160,11 @@ update msg model =
             ( newerModel, Cmd.batch [ Cmd.map Yay subCmd, outCommands ] )
 
         Tags sub ->
-           let
+            let
                 ( subModel, subCmd, outMsg ) =
                     Multiselect.update sub model.multiselectTagged
 
-                ( newSubModel, outCmd) =
+                ( newSubModel, outCmd ) =
                     case outMsg of
                         Just m ->
                             handleTag m subModel
@@ -162,16 +172,16 @@ update msg model =
                         Nothing ->
                             ( subModel, subCmd )
             in
-            ( {model | multiselectTagged = newSubModel}
-            , Cmd.batch (List.map (Cmd.map Tags) [ subCmd, outCmd] ))
+            ( { model | multiselectTagged = newSubModel }
+            , Cmd.batch (List.map (Cmd.map Tags) [ subCmd, outCmd ])
+            )
 
         TagsWithPrefix sub ->
             let
-                ( subModel, subCmd, outMsg) =
+                ( subModel, subCmd, outMsg ) =
                     Multiselect.update sub model.multiselectTaggedShowPrefix
 
-
-                ( newSubModel, outCmd) =
+                ( newSubModel, outCmd ) =
                     case outMsg of
                         Just m ->
                             handleTag m subModel
@@ -179,9 +189,9 @@ update msg model =
                         Nothing ->
                             ( subModel, subCmd )
             in
-            ( {model | multiselectTaggedShowPrefix = newSubModel}
-            ,  Cmd.batch (List.map (Cmd.map TagsWithPrefix) [ subCmd, outCmd ] ))
-
+            ( { model | multiselectTaggedShowPrefix = newSubModel }
+            , Cmd.batch (List.map (Cmd.map TagsWithPrefix) [ subCmd, outCmd ])
+            )
 
         SelectA ->
             ( { model | selectedA = Multiselect.getSelectedValues model.multiselectA }, Cmd.none )
@@ -250,7 +260,7 @@ handleTag msg multiselectModel =
                 ( populated, cmd ) =
                     addTag multiselectModel tag
             in
-            (populated , cmd )
+            ( populated, cmd )
 
         _ ->
             ( multiselectModel, Cmd.none )

--- a/example/src/MinimalExample.elm
+++ b/example/src/MinimalExample.elm
@@ -71,8 +71,12 @@ type alias Model =
 
 initModel : Model
 initModel =
-    { multiselectA = Multiselect.initModel valuesA "A" Multiselect.Hide
-    , multiselectB = Multiselect.initModel valuesB "B" Multiselect.Hide
+    let
+        config =
+            Multiselect.defaultConfig
+    in
+    { multiselectA = Multiselect.initModel { config | values = valuesA, tag = "A" }
+    , multiselectB = Multiselect.initModel { config | values = valuesB, tag = "B", isMultiSelect = False }
     }
 
 

--- a/example/src/MinimalExample.elm
+++ b/example/src/MinimalExample.elm
@@ -1,4 +1,4 @@
-module Main exposing (..)
+module MinimalExample exposing (..)
 
 -- Import Multiselect
 
@@ -71,8 +71,8 @@ type alias Model =
 
 initModel : Model
 initModel =
-    { multiselectA = Multiselect.initModel valuesA "A"
-    , multiselectB = Multiselect.initModel valuesB "B"
+    { multiselectA = Multiselect.initModel valuesA "A" Multiselect.Hide
+    , multiselectB = Multiselect.initModel valuesB "B" Multiselect.Hide
     }
 
 

--- a/src/Multiselect.elm
+++ b/src/Multiselect.elm
@@ -1,12 +1,12 @@
 module Multiselect exposing
-    ( initModel, getSelectedValues, populateValues, clearInputText, getValues
+    ( initModel, defaultConfig, getSelectedValues, populateValues, clearInputText, getValues, InputInMenu(..)
     , Model
     , Msg
     , OutMsg(..)
     , view
     , update
     , subscriptions
-    , InputInMenu(..)
+    , SelectItem
     )
 
 {-| An implementation of multiselect control built with and for Elm.
@@ -16,7 +16,7 @@ Please, check example/src/MinimalExample.elm for the minimal example on how to u
 
 # Helpers
 
-@docs initModel, getSelectedValues, populateValues, clearInputText, getValues, InputInMenu
+@docs initModel, defaultConfig, getSelectedValues, populateValues, clearInputText, getValues, InputInMenu
 
 
 # Model
@@ -93,30 +93,57 @@ type InputInMenu
 
 -}
 type Model
-    = Model
-        { status : Status
-        , values : List ( String, String )
-        , filtered : List ( String, String )
-        , selected : List ( String, String )
-        , protected : Bool
-        , error : Maybe String
-        , input : Maybe String
-        , inputWidth : Float
-        , hovered : Maybe ( String, String )
-        , tag : String
-        , inputInMenu : InputInMenu
-        }
+    = Model ModelState
 
 
-{-| Init model based on the values : List (String, String) and id : String provided by the user.
+type alias ModelState =
+    { status : Status
+    , values : List SelectItem
+    , filtered : List SelectItem
+    , selected : List SelectItem
+    , protected : Bool
+    , error : Maybe String
+    , input : Maybe String
+    , inputWidth : Float
+    , hovered : Maybe SelectItem
+    , tag : String
+    , inputInMenu : InputInMenu
+    , isMultiSelect : Bool
+    }
+
+
+type alias SelectItem =
+    ( String, String )
+
+
+type alias Config =
+    { values : List SelectItem
+    , tag : String
+    , inputInMenu : InputInMenu
+    , isMultiSelect : Bool
+    }
+
+
+{-| Default config for initModel.
+-}
+defaultConfig : Config
+defaultConfig =
+    { values = []
+    , tag = "id_multiselect"
+    , inputInMenu = Hide
+    , isMultiSelect = True
+    }
+
+
+{-| Init model based on the values : SelectItem and id : String provided by the user.
 
     model =
         { multiselect = Multiselect.initModel [ ( "one", "The 1st option" ), ( "two", "The 2nd option" ), ( "three", "The 3rd option" ) ] "id_1"
         }
 
 -}
-initModel : List ( String, String ) -> String -> InputInMenu -> Model
-initModel values tag1 inputInMenu =
+initModel : Config -> Model
+initModel ({ values, inputInMenu, isMultiSelect } as config) =
     Model
         { status = Closed
         , values = values
@@ -127,28 +154,29 @@ initModel values tag1 inputInMenu =
         , input = Just ""
         , inputWidth = 23.0
         , hovered = List.head values
-        , tag = tag1
+        , tag = config.tag
         , inputInMenu = inputInMenu
+        , isMultiSelect = isMultiSelect
         }
 
 
-{-| Get the full list of values : List (String, String)
+{-| Get the full list of values : SelectItem
 -}
-getValues : Model -> List ( String, String )
+getValues : Model -> List SelectItem
 getValues (Model model) =
     model.values
 
 
-{-| Get selected values : List (String, String)
+{-| Get selected values : SelectItem
 -}
-getSelectedValues : Model -> List ( String, String )
+getSelectedValues : Model -> List SelectItem
 getSelectedValues (Model model) =
     model.selected
 
 
-{-| Populate model with values : List (String, String) and preselect selected : List (String, String).
+{-| Populate model with values : SelectItem and preselect selected : SelectItem.
 -}
-populateValues : Model -> List ( String, String ) -> List ( String, String ) -> Model
+populateValues : Model -> List SelectItem -> List SelectItem -> Model
 populateValues (Model model) values selected =
     let
         filtered =
@@ -166,11 +194,27 @@ populateValues (Model model) values selected =
 clearInputText : Model -> ( Model, Cmd Msg )
 clearInputText (Model model) =
     ( Model { model | input = Nothing }
-    , Dom.focus ("multiselectInput" ++ model.tag) |> Task.attempt FocusResult
+    , focusInput model
     )
 
 
-valuesWithoutSelected : { selected : List ( String, String ), values : List ( String, String ) } -> List ( String, String )
+{-| Put browser focus on input element.
+-}
+focusInput : ModelState -> Cmd Msg
+focusInput model =
+    Dom.focus ("multiselectInput" ++ model.tag) |> Task.attempt FocusResult
+
+
+addSelected : SelectItem -> ModelState -> List SelectItem
+addSelected item model =
+    if model.isMultiSelect then
+        model.selected ++ [ item ]
+
+    else
+        [ item ]
+
+
+valuesWithoutSelected : { selected : List SelectItem, values : List SelectItem } -> List SelectItem
 valuesWithoutSelected { selected, values } =
     List.filter (\value -> not (List.member value selected)) values
 
@@ -187,14 +231,14 @@ type Msg
     | ClickOnComponent
     | DisableProtection
     | Toggle
-    | OnSelect ( String, String )
-    | RemoveItem ( String, String )
+    | OnSelect SelectItem
+    | RemoveItem SelectItem
     | Clear
     | FocusResult (Result Dom.Error ())
     | ScrollResult (Result Dom.Error ())
     | Filter String
     | Adjust Float
-    | OnHover ( String, String )
+    | OnHover SelectItem
     | Shortcut Int
     | ScrollY (Result Dom.Error Float)
 
@@ -202,8 +246,8 @@ type Msg
 {-| Transparent type for external library messages
 -}
 type OutMsg
-    = Selected ( String, String )
-    | Unselected ( String, String )
+    = Selected SelectItem
+    | Unselected SelectItem
     | Cleared
     | NotFound String
 
@@ -227,17 +271,13 @@ update msg (Model model) =
         Toggle ->
             if model.status == Opened then
                 ( Model { model | status = Closed }
-                , Cmd.batch
-                    [ Dom.focus ("multiselectInput" ++ model.tag) |> Task.attempt FocusResult
-                    ]
+                , Cmd.batch [ focusInput model ]
                 , Nothing
                 )
 
             else
                 ( Model { model | status = Opened }
-                , Cmd.batch
-                    [ Dom.focus ("multiselectInput" ++ model.tag) |> Task.attempt FocusResult
-                    ]
+                , Cmd.batch [ focusInput model ]
                 , Nothing
                 )
 
@@ -258,7 +298,7 @@ update msg (Model model) =
             else
                 ( Model { model | status = Opened, protected = True }
                 , Cmd.batch
-                    [ Dom.focus ("multiselectInput" ++ model.tag) |> Task.attempt FocusResult
+                    [ focusInput model
                     , delayInMs 100 <| DisableProtection
                     ]
                 , Nothing
@@ -374,10 +414,13 @@ update msg (Model model) =
         OnSelect item ->
             let
                 selected =
-                    model.selected ++ [ item ]
+                    model |> addSelected item
 
                 filtered =
-                    valuesWithoutSelected { selected = selected, values = model.values }
+                    valuesWithoutSelected
+                        { selected = selected
+                        , values = model.values
+                        }
             in
             ( Model
                 { model
@@ -386,15 +429,14 @@ update msg (Model model) =
                     , hovered = nextSelectedItem model.filtered item
                     , input = Nothing
                     , status =
-                        if List.isEmpty filtered then
+                        if List.isEmpty filtered || not model.isMultiSelect then
                             Closed
 
                         else
                             Opened
                 }
             , Cmd.batch
-                [ Dom.focus ("multiselectInput" ++ model.tag) |> Task.attempt FocusResult
-                ]
+                [ focusInput model ]
             , Just (Selected item)
             )
 
@@ -425,9 +467,7 @@ update msg (Model model) =
                     , input = Nothing
                     , status = Closed
                 }
-            , Cmd.batch
-                [ Dom.focus ("multiselectInput" ++ model.tag) |> Task.attempt FocusResult
-                ]
+            , Cmd.batch [ focusInput model ]
             , Just Cleared
             )
 
@@ -553,7 +593,7 @@ update msg (Model model) =
                                     ( id, val )
 
                                 selected =
-                                    model.selected ++ [ item ]
+                                    model |> addSelected item
 
                                 filtered =
                                     valuesWithoutSelected { selected = selected, values = model.values }
@@ -571,9 +611,7 @@ update msg (Model model) =
                                         else
                                             Opened
                                 }
-                            , Cmd.batch
-                                [ Dom.focus ("multiselectInput" ++ model.tag) |> Task.attempt FocusResult
-                                ]
+                            , Cmd.batch [ focusInput model ]
                             , Just (Selected item)
                             )
 
@@ -879,20 +917,24 @@ tags (Model model) =
     div [ css [ SelectCss.tagWrap ] ]
         (List.map
             (\( name, value ) ->
-                tag name value
+                tag model.isMultiSelect name value
             )
             model.selected
         )
 
 
-tag : String -> String -> Html.Styled.Html Msg
-tag name value =
+tag : Bool -> String -> String -> Html.Styled.Html Msg
+tag isRemovable name value =
     div [ css [ SelectCss.tag ] ]
-        [ span
-            [ css [ SelectCss.tagIcon ]
-            , onClick (RemoveItem ( name, value ))
-            ]
-            [ text "×" ]
+        [ if isRemovable then
+            span
+                [ css [ SelectCss.tagIcon ]
+                , onClick (RemoveItem ( name, value ))
+                ]
+                [ text "×" ]
+
+          else
+            text ""
         , span [ css [ SelectCss.tagLabel ] ] [ text value ]
         ]
 

--- a/src/Multiselect.elm
+++ b/src/Multiselect.elm
@@ -54,7 +54,6 @@ import Browser.Dom as Dom
 import Browser.Events as BrowserEvents
 import DOM
 import Html exposing (Html)
-import Html.Events as Events
 import Html.Styled
     exposing
         ( div
@@ -69,8 +68,7 @@ import Multiselect.Keycodes as Keycodes
 import Multiselect.SelectCss as SelectCss
 import Process
 import String
-import Task as Task exposing (Task)
-import Time
+import Task exposing (Task)
 
 
 type Status


### PR DESCRIPTION
NOTE: This commit changes the API for `initModel` and therefore not backward compatible.

Enable a multiselect component to be [initialized as single-select](https://github.com/inkuzmin/elm-multiselect/issues/44). In this case:

  - A user is only able to pick one item from the options
  - The [x] button is removed from the tag
  
Excerpt from `MinimalExample.elm`:

```elm
initModel : Model
initModel =
    let
        config =
            Multiselect.defaultConfig
    in
    { multiselectA = Multiselect.initModel { config | values = valuesA, tag = "A" }
    , multiselectB = Multiselect.initModel { config | values = valuesB, tag = "B", isMultiSelect = False }
    }
```